### PR TITLE
Extracting interfaces from BaseDataProvider and BasePage

### DIFF
--- a/src/CrudKit/Controllers/BaseController.php
+++ b/src/CrudKit/Controllers/BaseController.php
@@ -3,7 +3,7 @@
 namespace CrudKit\Controllers;
 
 use CrudKit\CrudKitApp;
-use CrudKit\Pages\BasePage;
+use CrudKit\Pages\Page;
 use CrudKit\Util\FlashBag;
 use CrudKit\Util\TwigUtil;
 use CrudKit\Util\ValueBag;
@@ -29,7 +29,7 @@ class BaseController {
     protected $twig = null;
 
     /**
-     * @var BasePage
+     * @var Page
      */
     protected $page = null;
 
@@ -94,7 +94,7 @@ class BaseController {
                 break;
             case "transclude":
                 $pageMap = [];
-                /** @var BasePage $pageItem */
+                /** @var Page $pageItem */
                 foreach($this->app->getPages() as $pageItem) {
                     $pageMap []= array(
                         'id' => $pageItem->getId(),

--- a/src/CrudKit/CrudKitApp.php
+++ b/src/CrudKit/CrudKitApp.php
@@ -3,7 +3,7 @@
 namespace CrudKit;
 
 use CrudKit\Controllers\MainController;
-use CrudKit\Pages\BasePage;
+use CrudKit\Pages\Page;
 use CrudKit\Util\TwigUtil;
 use Twig_Autoloader;
 use Twig_Environment;
@@ -56,7 +56,7 @@ class CrudKitApp {
     }
 
     /**
-     * @param $page BasePage
+     * @param $page Page
      */
     public function addPage ($page) {
         $this->pages []= $page;
@@ -110,7 +110,7 @@ class CrudKitApp {
 
     /**
      * @param $id
-     * @return BasePage
+     * @return Page
      */
     public function getPageById ($id) {
         if(isset($this->pageById[$id])) {

--- a/src/CrudKit/Data/BaseDataProvider.php
+++ b/src/CrudKit/Data/BaseDataProvider.php
@@ -2,7 +2,7 @@
 
 namespace CrudKit\Data;
 
-use CrudKit\Pages\BasePage;
+use CrudKit\Pages\Page;
 use CrudKit\Util\FormHelper;
 use CrudKit\Util\RouteGenerator;
 use CrudKit\Util\UrlHelper;
@@ -12,13 +12,10 @@ abstract class BaseDataProvider implements DataProvider
     protected $initQueue = array();
 
     /**
-     * @var BasePage
+     * @var Page
      */
     protected $page = null;
 
-    public function setPage ($page) {
-        $this->page = $page;
-    }
     public function init ()
     {
         foreach($this->initQueue as $item) {
@@ -31,4 +28,8 @@ abstract class BaseDataProvider implements DataProvider
         return new FormHelper([], $this->getEditFormConfig());
     }
 
+    public function setPage(Page $page)
+    {
+        $this->page = $page;
+    }
 }

--- a/src/CrudKit/Data/BaseDataProvider.php
+++ b/src/CrudKit/Data/BaseDataProvider.php
@@ -7,37 +7,8 @@ use CrudKit\Util\FormHelper;
 use CrudKit\Util\RouteGenerator;
 use CrudKit\Util\UrlHelper;
 
-abstract class BaseDataProvider {
-    // Data modelling
-    public abstract function getData ($params = array());
-    public abstract function getSchema ();
-    public abstract function getRowCount ($params = array());
-
-    // Ordering
-    public abstract function getSummaryColumns ();
-    public abstract function getEditFormOrder ();
-
-    // Individual values
-    public abstract function getRow ($id = null);
-    public abstract function setRow ($id = null, $values = array());
-
-    // Editing Options
-    public abstract function getEditFormConfig ();
-
-    public abstract function deleteMultipleItems ($ids);
-
-    public function getEditForm () {
-        $form = new FormHelper(array(), $this->getEditFormConfig());
-
-        return $form;
-    }
-
-    public function init () {
-        foreach($this->initQueue as $item) {
-            $item->init();
-        }
-    }
-
+abstract class BaseDataProvider implements DataProvider
+{
     protected $initQueue = array();
 
     /**
@@ -48,20 +19,16 @@ abstract class BaseDataProvider {
     public function setPage ($page) {
         $this->page = $page;
     }
-    public function getRelationshipValues($id, $foreign_key) {
-        return array(
-            'type' => 'json',
-            'data' => array(
-                'values' => array()
-            )
-        );
+    public function init ()
+    {
+        foreach($this->initQueue as $item) {
+            $item->init();
+        }
     }
 
-    public abstract function createItem($values);
+    public function getEditForm ()
+    {
+        return new FormHelper([], $this->getEditFormConfig());
+    }
 
-    public abstract function deleteItem($rowId);
-
-    //validation
-    public abstract function validateRequiredRow ($values = array());
-    public abstract function validateRow ($values = array());
 }

--- a/src/CrudKit/Data/DataProvider.php
+++ b/src/CrudKit/Data/DataProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace CrudKit\Data;
 
-use CrudKit\Pages\BasePage;
+use CrudKit\Pages\Page;
 use CrudKit\Util\FormHelper;
 
 //TODO: Write Proper API Documentation
@@ -79,9 +79,9 @@ interface DataProvider
     public function getEditForm();
 
     /**
-     * @param BasePage $page
+     * @param Page $page
      */
-    public function setPage(BasePage $page);
+    public function setPage(Page $page);
 
     /**
      * @param $id

--- a/src/CrudKit/Data/DataProvider.php
+++ b/src/CrudKit/Data/DataProvider.php
@@ -1,0 +1,104 @@
+<?php
+namespace CrudKit\Data;
+
+use CrudKit\Pages\BasePage;
+use CrudKit\Util\FormHelper;
+
+//TODO: Write Proper API Documentation
+interface DataProvider
+{
+
+    public function init();
+
+    /**
+     * @return array
+     */
+    public function getSchema();
+
+    /**
+     * @param array $params
+     * @return int
+     */
+    public function getRowCount(array $params = []);
+
+    /**
+     * @return array
+     */
+    public function getSummaryColumns();
+
+    /**
+     * @param array $params
+     * @return array
+     */
+    public function getData(array $params = []);
+
+    /**
+     * @param mixed $id
+     * @return array
+     */
+    public function getRow($id = null);
+
+    /**
+     * @param mixed $id
+     * @param array $values
+     * @return true
+     */
+    public function setRow($id = null, array $values = []);
+
+    /**
+     * @param array $values
+     * @return int
+     */
+    public function createItem(array $values);
+
+    /**
+     * @param mixed $rowId
+     * @return bool
+     */
+    public function deleteItem($rowId);
+
+    /**
+     * @param array $ids
+     * @return bool
+     */
+    public function deleteMultipleItems($ids);
+
+    /**
+     * @return array
+     */
+    public function getEditFormConfig();
+
+    /**
+     * @return array
+     */
+    public function getEditFormOrder();
+
+    /**
+     * @return FormHelper
+     */
+    public function getEditForm();
+
+    /**
+     * @param BasePage $page
+     */
+    public function setPage(BasePage $page);
+
+    /**
+     * @param $id
+     * @param $foreign_key
+     * @return array
+     */
+    public function getRelationshipValues($id, $foreign_key);
+
+    /**
+     * @param array $values
+     * @return array
+     */
+    public function validateRequiredRow(array $values = []);
+
+    /**
+     * @param array $values
+     * @return array
+     */
+    public function validateRow(array $values = []);
+}

--- a/src/CrudKit/Data/DummyDataProvider.php
+++ b/src/CrudKit/Data/DummyDataProvider.php
@@ -4,9 +4,10 @@ namespace CrudKit\Data;
 
 use CrudKit\Util\LoggingHelper;
 
-class DummyDataProvider extends BaseDataProvider {
+class DummyDataProvider extends BaseDataProvider
+{
 
-    public function getData($params = array())
+    public function getData(array $params = array())
     {
         $skip = isset($params['skip']) ? $params['skip'] : 0;
         $take = isset($params['take']) ? $params['take'] : 10;
@@ -55,7 +56,7 @@ class DummyDataProvider extends BaseDataProvider {
         );
     }
 
-    public function getRowCount()
+    public function getRowCount(array $params = [])
     {
         return 100;
     }
@@ -90,9 +91,69 @@ class DummyDataProvider extends BaseDataProvider {
         );
     }
 
-    public function setRow($id = null, $values = array())
+    public function setRow($id = null, array $values = [])
     {
         $log = new LoggingHelper();
         $log->vardump($values);
+    }
+
+    /**
+     * @param array $values
+     * @return int
+     */
+    public function createItem(array $values)
+    {
+        throw new \Exception('This Data Provider does not support creating additional data.');
+    }
+
+    /**
+     * @param mixed $rowId
+     * @return bool
+     */
+    public function deleteItem($rowId)
+    {
+        return true;
+    }
+
+    /**
+     * @param array $ids
+     * @return bool
+     */
+    public function deleteMultipleItems($ids)
+    {
+        return true;
+    }
+
+    /**
+     * @param $id
+     * @param $foreign_key
+     * @return array
+     */
+    public function getRelationshipValues($id, $foreign_key)
+    {
+        return [
+            'type' => 'json',
+            'data' => [
+                'values' => []
+            ]
+        ];
+    }
+
+    /**
+     * @param array $values
+     * @return array
+     */
+    public function validateRequiredRow(array $values = [])
+    {
+        return [];
+    }
+
+    /**
+     * @param array $values
+     * @return array
+     */
+    public function validateRow(array $values = [])
+    {
+        return [];
     }
 }

--- a/src/CrudKit/Data/SQLDataProvider.php
+++ b/src/CrudKit/Data/SQLDataProvider.php
@@ -254,7 +254,7 @@ class SQLDataProvider extends BaseSQLDataProvider{
         $this->tableName = $table;
     }
 
-    public function getData($params = array())
+    public function getData(array $params = array())
     {
         $skip = isset($params['skip']) ? $params['skip'] : 0;
         $take = isset($params['take']) ? $params['take'] : 10;
@@ -316,7 +316,7 @@ class SQLDataProvider extends BaseSQLDataProvider{
         return $this->queryColumns("category", array(SQLColumn::CATEGORY_VALUE, SQLColumn::CATEGORY_PRIMARY), "schema", true);
     }
 
-    public function getRowCount($params = array())
+    public function getRowCount(array $params = [])
     {
         $builder = $this->conn->createQueryBuilder();
         $builder->select(array("COUNT(".$this->getPrimaryColumn()->getExpr().") AS row_count"))
@@ -376,7 +376,7 @@ class SQLDataProvider extends BaseSQLDataProvider{
         return $this->prepareObjectForClient($values);
     }
 
-    public function setRow($id = null, $values = array())
+    public function setRow($id = null, array $values = [])
     {
         $builder = $this->conn->createQueryBuilder();
         $pk = $this->getPrimaryColumn()->getExpr();
@@ -409,7 +409,7 @@ class SQLDataProvider extends BaseSQLDataProvider{
         return $status;
     }
 
-    public function createItem($values)
+    public function createItem(array $values)
     {
         $builder = $this->conn->createQueryBuilder();
         $builder->insert($this->tableName);
@@ -443,7 +443,7 @@ class SQLDataProvider extends BaseSQLDataProvider{
         return $status;
     }
 
-    public function validateRequiredRow($values = array()) {
+    public function validateRequiredRow(array $values = array()) {
         $failed = array();
         foreach($this->columns as $columnKey => $col) {
             if(isset($col->options["required"]) && $col->options["required"]) {
@@ -455,7 +455,7 @@ class SQLDataProvider extends BaseSQLDataProvider{
         return $failed;
     }
 
-    public function validateRow($values = array()) {
+    public function validateRow(array $values = array()) {
         $failed = array();
         foreach($values as $formKey => $formValue) {
             $col = null;

--- a/src/CrudKit/Form/OneToManyItem.php
+++ b/src/CrudKit/Form/OneToManyItem.php
@@ -3,6 +3,7 @@
 namespace CrudKit\Form;
 
 use CrudKit\Data\BaseDataProvider;
+use CrudKit\Data\DataProvider;
 
 class OneToManyItem extends BaseFormItem {
 
@@ -12,7 +13,7 @@ class OneToManyItem extends BaseFormItem {
         $label = $this->config['label'];
 
         /**
-         * @var $provider BaseDataProvider
+         * @var $provider DataProvider
          */
         $provider = $this->config['fk_provider'];
         $providerForm = $provider->getEditForm();

--- a/src/CrudKit/Pages/BasePage.php
+++ b/src/CrudKit/Pages/BasePage.php
@@ -2,9 +2,8 @@
 
 namespace CrudKit\Pages;
 
-abstract class BasePage {
-    abstract function render ();
-
+abstract class BasePage implements Page
+{
     protected $name = "";
     protected $id = null;
 

--- a/src/CrudKit/Pages/BasicDataPage.php
+++ b/src/CrudKit/Pages/BasicDataPage.php
@@ -3,6 +3,7 @@
 namespace CrudKit\Pages;
 
 use CrudKit\Data\BaseDataProvider;
+use CrudKit\Data\DataProvider;
 use CrudKit\Util\FormHelper;
 use CrudKit\Util\LoggingHelper;
 use CrudKit\Util\RouteGenerator;
@@ -313,12 +314,12 @@ class BasicDataPage extends BasePage{
     }
 
     /**
-     * @var BaseDataProvider
+     * @var DataProvider
      */
     protected $dataProvider = null;
 
     /**
-     * @return BaseDataProvider
+     * @return DataProvider
      */
     public function getDataProvider()
     {
@@ -326,7 +327,7 @@ class BasicDataPage extends BasePage{
     }
 
     /**
-     * @param BaseDataProvider $dataProvider
+     * @param DataProvider $dataProvider
      */
     public function setDataProvider($dataProvider)
     {

--- a/src/CrudKit/Pages/Page.php
+++ b/src/CrudKit/Pages/Page.php
@@ -1,0 +1,30 @@
+<?php
+namespace CrudKit\Pages;
+
+//TODO: Add code documentation
+interface Page
+{
+    /**
+     * @return mixed
+     */
+    public function getId();
+
+
+    public function init($app = null);
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function setName($name);
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @return string
+     */
+    public function render();
+}


### PR DESCRIPTION
Resolves #31.

Extracts the abstract methods from `BaseDataProvider` into a `DataProvider` interface and adds a few array typehints where non-array parameters would obviously break. Likewise extracts an interface from `BasePage` into `Page`. The latter isn't that useful at the moment but opens the window for more refactoring later.